### PR TITLE
Fix translation path validation bug

### DIFF
--- a/src/utils/validateTranslation.ts
+++ b/src/utils/validateTranslation.ts
@@ -13,11 +13,22 @@ export function validateTranslationPath(path: string): boolean {
     const parts = path.split('.');
     let current: any = translationSchema.shape;
 
-    for (const part of parts) {
-        if (!current[part]) {
+    for (let i = 0; i < parts.length; i++) {
+        const key = parts[i];
+        const next = current[key];
+
+        if (!next) {
             return false;
         }
-        current = current[part].shape;
+
+        const isLast = i === parts.length - 1;
+
+        if ('shape' in next) {
+            current = next.shape;
+        } else if (!isLast) {
+            // reached a leaf node but there are still segments
+            return false;
+        }
     }
 
     return true;


### PR DESCRIPTION
## Summary
- fix translation path validation so it doesn't crash when an extra key is provided

## Testing
- `pnpm lint` *(fails: Invalid environment variables)*
- `pnpm typecheck` *(fails: multiple TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c3d3fc3c083238cf1524732c742de