### PR TITLE
Fix invoice router and extract shared utilities

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,43 +1,43 @@
-// import tseslint from "@typescript-eslint/eslint-plugin";
-// import eslintParser from "@typescript-eslint/parser";
+import tseslint from "@typescript-eslint/eslint-plugin";
+import eslintParser from "@typescript-eslint/parser";
 
-// /** @type {import("eslint").Linter.Config} */
-// const config = {
-//   parser: "@typescript-eslint/parser",
-//   parserOptions: {
-//     project: true,
-//   },
-//   plugins: { "@typescript-eslint": tseslint },
-//   extends: [
-//     "next/core-web-vitals",
-//     "plugin:@typescript-eslint/recommended-type-checked",
-//     "plugin:@typescript-eslint/stylistic-type-checked",
-//   ],
-//   rules: {
-//     "@typescript-eslint/array-type": "off",
-//     "@typescript-eslint/consistent-type-definitions": "off",
-//     "@typescript-eslint/consistent-type-imports": [
-//       "warn",
-//       {
-//         prefer: "type-imports",
-//         fixStyle: "inline-type-imports",
-//       },
-//     ],
-//     "@typescript-eslint/no-unused-vars": [
-//       "warn",
-//       {
-//         argsIgnorePattern: "^_",
-//       },
-//     ],
-//     "@typescript-eslint/require-await": "off",
-//     "@typescript-eslint/no-misused-promises": [
-//       "error",
-//       {
-//         checksVoidReturn: {
-//           attributes: false,
-//         },
-//       },
-//     ],
-//   },
-// };
-// module.exports = config;
+/** @type {import("eslint").Linter.Config} */
+const config = {
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: true,
+  },
+  plugins: { "@typescript-eslint": tseslint },
+  extends: [
+    "next/core-web-vitals",
+    "plugin:@typescript-eslint/recommended-type-checked",
+    "plugin:@typescript-eslint/stylistic-type-checked",
+  ],
+  rules: {
+    "@typescript-eslint/array-type": "off",
+    "@typescript-eslint/consistent-type-definitions": "off",
+    "@typescript-eslint/consistent-type-imports": [
+      "warn",
+      {
+        prefer: "type-imports",
+        fixStyle: "inline-type-imports",
+      },
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        argsIgnorePattern: "^_",
+      },
+    ],
+    "@typescript-eslint/require-await": "off",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        checksVoidReturn: {
+          attributes: false,
+        },
+      },
+    ],
+  },
+};
+module.exports = config;

--- a/src/components/common/withAuth.tsx
+++ b/src/components/common/withAuth.tsx
@@ -4,8 +4,8 @@ import { useSession } from "next-auth/react"
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
 
-export function withAuth(WrappedComponent: React.ComponentType) {
-  return function ProtectedRoute(props: any) {
+export function withAuth<P>(WrappedComponent: React.ComponentType<P>) {
+  return function ProtectedRoute(props: P): JSX.Element {
     const { data: session, status } = useSession()
     const router = useRouter()
 
@@ -19,7 +19,7 @@ export function withAuth(WrappedComponent: React.ComponentType) {
     }
 
     if (!session) {
-      return null
+      return <div>Redirecting...</div>
     }
 
     return <WrappedComponent {...props} />

--- a/src/components/features/units/UnitList.tsx
+++ b/src/components/features/units/UnitList.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { Button } from "@/components/ui/button";
+import { getPlateColor } from "@/utils/vehicle";
 import type {
   Unit,
   Resident,
@@ -45,24 +46,6 @@ const UnitList: React.FC<UnitListProps> = ({
   setEditingResident,
   setEditingVehicle,
 }) => {
-  const getPlateColor = (type: string) => {
-    switch (type) {
-      case "commercial":
-      case "taxi":
-      case "driving_school":
-        return "text-red-600";
-      case "official":
-        return "text-blue-600";
-      case "test":
-        return "text-green-600";
-      case "diplomatic":
-        return "text-yellow-600";
-      case "collection":
-        return "text-gray-400";
-      default:
-        return "text-black";
-    }
-  };
 
   const handleDeleteUnit = (id: string) => {
     onDeleteUnit(id);

--- a/src/components/features/vehicles/VehicleForm.tsx
+++ b/src/components/features/vehicles/VehicleForm.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import type { Vehicle } from "@/types/unit";
+import { getPlateColor } from "@/utils/vehicle";
 
 type VehicleFormData = Omit<Vehicle, "id">;
 
@@ -38,25 +39,6 @@ export default function VehicleForm({
     if (!vehicle) reset();
   };
 
-  // Get plate color based on vehicle type
-  const getPlateColor = (type: string) => {
-    switch (type) {
-      case "commercial":
-      case "taxi":
-      case "driving_school":
-        return "text-red-600";
-      case "official":
-        return "text-blue-600";
-      case "test":
-        return "text-green-600";
-      case "diplomatic":
-        return "text-yellow-600";
-      case "collection":
-        return "text-gray-400";
-      default:
-        return "text-black";
-    }
-  };
 
   return (
     <form onSubmit={handleSubmit(onSubmitForm)} className="space-y-4">

--- a/src/server/api/routers/invoice.ts
+++ b/src/server/api/routers/invoice.ts
@@ -15,7 +15,7 @@ export const invoiceRouter = createTRPCRouter({
 
             // If user is a resident, only show their invoices
             if (ctx.session.user.role === 'resident') {
-                const units = await ctx.prisma.unit.findMany({
+                const units = await ctx.db.unit.findMany({
                     where: { ownerId: ctx.session.user.id },
                     select: { id: true },
                 });
@@ -33,7 +33,7 @@ export const invoiceRouter = createTRPCRouter({
                 filters.isPaid = input.isPaid;
             }
 
-            return ctx.prisma.invoice.findMany({
+            return ctx.db.invoice.findMany({
                 where: filters,
                 include: {
                     unit: {
@@ -68,7 +68,7 @@ export const invoiceRouter = createTRPCRouter({
         )
         .mutation(async ({ ctx, input }) => {
             // Validate unit exists
-            const unit = await ctx.prisma.unit.findUnique({
+            const unit = await ctx.db.unit.findUnique({
                 where: { id: input.unitId },
             });
 
@@ -79,7 +79,7 @@ export const invoiceRouter = createTRPCRouter({
                 });
             }
 
-            return ctx.prisma.invoice.create({
+            return ctx.db.invoice.create({
                 data: {
                     unitId: input.unitId,
                     amount: input.amount,

--- a/src/utils/vehicle.ts
+++ b/src/utils/vehicle.ts
@@ -1,0 +1,18 @@
+export function getPlateColor(type: string): string {
+  switch (type) {
+    case "commercial":
+    case "taxi":
+    case "driving_school":
+      return "text-red-600";
+    case "official":
+      return "text-blue-600";
+    case "test":
+      return "text-green-600";
+    case "diplomatic":
+      return "text-yellow-600";
+    case "collection":
+      return "text-gray-400";
+    default:
+      return "text-black";
+  }
+}


### PR DESCRIPTION
## Summary
- enable ESLint configuration
- improve `withAuth` typings and fallback
- use shared `getPlateColor` utility in forms and lists
- use `ctx.db` in invoice router to access Prisma

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc3e7b97c832393cf7cd23fa39d79